### PR TITLE
Had a problem handling incomplete messages

### DIFF
--- a/src/php/protocol.class.php
+++ b/src/php/protocol.class.php
@@ -111,7 +111,7 @@ class BinTreeNodeReader
         $stanzaSize = $this->peekInt16();
         if ($stanzaSize > strlen($this->_input))
         {
-            $exception = new IncompleteMessageException();
+            $exception = new IncompleteMessageException("Incomplete message");
             $exception->setInput($this->_input);
             throw $exception;
         }


### PR DESCRIPTION
Somehow when throwing the IncompleteMessageException the message parameter was not being set which was causing yet another exception (and causing incomplete message handling not to work), not sure how this got in there because the whole history of the file is gone! :(
