### PR TITLE
Support for sending to group chats

### DIFF
--- a/src/php/whatsprot.class.php
+++ b/src/php/whatsprot.class.php
@@ -9,6 +9,7 @@ class WhatsProt
 
     protected $_whatsAppHost = "bin-short.whatsapp.net";
     protected $_whatsAppServer = "s.whatsapp.net";
+    protected $_whatsAppGroupServer = "g.us";
     protected $_whatsAppRealm = "s.whatsapp.net";
     protected $_whatsAppDigest = "xmpp/s.whatsapp.net";
     protected $_device = "iPhone";
@@ -263,6 +264,11 @@ class WhatsProt
 
     public function Message($msgid, $to, $txt)
     {
+        $whatsAppServer = $this->_whatsAppServer;
+        if(strpos($to, "-") !== false)
+        {
+            $whatsAppServer = $this->_whatsAppGroupServer;
+        }
         $bodyNode = new ProtocolNode("body", null, null, $txt);
         $serverNode = new ProtocolNode("server", null, null, "");
 
@@ -271,7 +277,7 @@ class WhatsProt
         $xNode = new ProtocolNode("x", $xHash, array($serverNode), "");
 
         $messageHash = array();
-        $messageHash["to"] = $to . "@" . $this->_whatsAppServer;
+        $messageHash["to"] = $to . "@" . $whatsAppServer;
         $messageHash["type"] = "chat";
         $messageHash["id"] = $msgid;
         $messsageNode = new ProtocolNode("message", $messageHash, array($xNode, $bodyNode), "");


### PR DESCRIPTION
I've added support for sending messages to group chats.
The JID for group chats consists of the JID of the group owner, followed by a hyphen and an id. The server for group chats is 'g.us' instead of 's.whatsapp.net'. 

My change checks for the existance of a hyphen to determine whether the recipient is a group chat. If so, it uses 'g.us' as the server.

In case this is not known: The easiest way to find the JID for a group chat is to find the profile image in /sdcard/WhatsApp/Profile Pictures. The JID is the name of the image. (Without the extension of course)
