### PR TITLE
Add nickname function for Iphone client

### DIFF
--- a/src/php/whatsprot.class.php
+++ b/src/php/whatsprot.class.php
@@ -314,6 +314,15 @@ class WhatsProt
 	$this->sendNode($messsageNode);
     }
 
+    public function sendNickname($nickname)
+    {
+        $messageHash = array();
+        $messageHash["name"] = $nickname;
+        $messsageNode = new ProtocolNode("presence", $messageHash, null, "");
+        $this->sendNode($messsageNode);
+    }
+
+
     protected function DebugPrint($debugMsg)
     {
         if ($this->_debug)


### PR DESCRIPTION
A nickname has to be sent at the beginning of the session. When not set the Iphone client will display the phonenumber instead of the name. The nickname can be changed during the session.

Fix for issues/76
