### PR TITLE
fixes crash while polling for messages

### DIFF
--- a/src/php/protocol.class.php
+++ b/src/php/protocol.class.php
@@ -126,7 +126,8 @@ class BinTreeNodeReader
         $this->readInt24();
         if (($stanzaFlag & 8) && isset($this->_key))
         {
-            $this->_input = $this->_key->decode($this->_input, 0, $stanzaSize);
+			$remainingData = substr($this->_input, $stanzaSize);
+            $this->_input = $this->_key->decode($this->_input, 0, $stanzaSize) . $remainingData;
         }
         if ($stanzaSize > 0)
         {


### PR DESCRIPTION
when polling for messages, a chunk of data is read from the socket and fed to `BinTreeNodeReader::nextTree()` which saves the data in its input buffer (`_input`).

The problem occurs when decrypting: when multiple nodes are in the `_input` variable, only the first one gets decrypted, the rest of the data is lost. If the rest of the data was half a message, the next time `BinTreeNode::nextTree()` is executed, it might run into corrupt data.

This probably is not the perfect solution, but WhatsAPI stopped crashing for me after applying this patch..
