### PR TITLE
Auto Thumbnail creation for sent images

### DIFF
--- a/src/php/func.php
+++ b/src/php/func.php
@@ -67,7 +67,7 @@ function startsWith($haystack, $needle , $pos=0){
 
 function endsWith($haystack, $needle){
     $length = strlen($needle);
-    $start  = $length * -1; 
+    $start  = $length * -1;
     return (substr($haystack, $start) === $needle);
 }
 
@@ -84,4 +84,11 @@ function createIcon($file)
     $fp = fopen($outfile, "w");
     fwrite($fp, $b64);
     fclose($fp);
+}
+
+function resize_image($image, $w, $h) {
+    $img = new Imagick();
+    $img->readImageBlob($image);
+    $img->thumbnailImage($w, $h, TRUE);
+    return base64_encode($img);
 }


### PR DESCRIPTION
Firstly, this is my first ever contribution to an open source project, I'm still learning the tools - so any mistakes are entirely mine! Go easy on me - point out the mistakes but no shouting ;)

I have been looking at the MessageImage function in Whatsapi and was getting frustrated at having to build my own thumbnails every time I wanted to send an image.

So I decided to use the features of imagick that I hope most people have enabled in php to do this for me automatically when you try and send an image.

There is a full example of how to send an image as a message below. However I do have some questions that I don't know the answer too.

1) In the MessageImage method, (around line 276 in whatsprot.class.php) what purpose does the line:
**$mediaAttribs["file"] = $file;**

serve? Is this for Android for it to save the image to the phone as a particular filename?

2)Why must we supply the image from a URL online, if an image exists on the server/computer we are sending from, why can we not use that? I have tried using a local file (not accessable via http request) and whilst the thumbnail worked perfectly I was unable to download the received message/image on the phone.

3) I have no idea why there are so many edits in the src/php/whatsprot.class.php that seem to be related to removing blank lines and replacing them. If anyone can explain to this noob why that happened I'd be grateful.

Anyway, I hope this helps someone else. Seems to be working very well here

``` php
<?php
    require "whatsprot.class.php";

    $fromMobNumber = "1234567890";
    $toMobNumber = "0987654321";
    $id = "<YOUR_MAC_OR_IEMI_DEPENDING_ON_PLATFORM>";
    $nick = "YourNick";
    $imgurl = "http://www.picastro.net/wp-content/uploads/2010/04/funny-dog-costume.jpg";

    $w = new WhatsProt($fromMobNumber, $id, $nick);
    $w->Connect();
    $w->Login();
    $w->sendNickname($nick);

    $w->MessageImage(time() . "-1", $toMobNumber, $imgurl);
    sleep (4);

?>
```
