### PR TITLE
Fix php notice: undefined index id

### DIFF
--- a/src/php/whatsprot.class.php
+++ b/src/php/whatsprot.class.php
@@ -339,14 +339,13 @@ class WhatsProt
                     if ($node->getChild('composing') != NULL) {
                         $this->eventManager()->fire('onUserComposing', array(
                             $this->_phoneNumber,
-                            $node->_attributeHash['from'], $node->_attributeHash['id'], $node->_attributeHash['type'], $node->_attributeHash['t']
+                            $node->_attributeHash['from'], $node->_attributeHash['type'], $node->_attributeHash['t']
                         ));
                     }
                     if ($node->getChild('paused') != NULL) {
                         $this->eventManager()->fire('onUserPaused', array(
                             $this->_phoneNumber,
                             $node->_attributeHash['from'],
-                            $node->_attributeHash['id'],
                             $node->_attributeHash['type'],
                             $node->_attributeHash['t']
                         ));


### PR DESCRIPTION
**Notice: Undefined index: id in E:\web...\whatsprot.class.php on line 342**

The node does not has attribute `$node->_attributeHash['id']`
See https://github.com/venomous0x/WhatsAPI/blob/master/src/php/whatsprot.class.php#L342

```
object(ProtocolNode)#494 (4) {
  ["_tag"]=>
  string(7) "message"
  ["_attributeHash"]=>
  array(3) {
    ["from"]=>
    string(26) "XXXXXXXXX@s.whatsapp.net"
    ["type"]=>
    string(4) "chat"
    ["t"]=>
    string(10) "1362627450"
  }
  ["_children"]=>
  array(1) {
    [0]=>
    object(ProtocolNode)#493 (4) {
      ["_tag"]=>
      string(9) "composing"
      ["_attributeHash"]=>
      array(1) {
        ["xmlns"]=>
        string(37) "http://jabber.org/protocol/chatstates"
      }
      ["_children"]=>
      NULL
      ["_data"]=>
      string(0) ""
    }
  }
  ["_data"]=>
  string(0) ""
}
```

**Notice: Undefined index: id in E:\web...\whatsprot.class.php on line 349**

The node does not has attribute `$node->_attributeHash['id']`
see https://github.com/venomous0x/WhatsAPI/blob/master/src/php/whatsprot.class.php#L349

```
object(ProtocolNode)#489 (4) {
  ["_tag"]=>
  string(7) "message"
  ["_attributeHash"]=>
  array(3) {
    ["from"]=>
    string(26) "XXXXXXXXX@s.whatsapp.net"
    ["type"]=>
    string(4) "chat"
    ["t"]=>
    string(10) "1362627037"
  }
  ["_children"]=>
  array(1) {
    [0]=>
    object(ProtocolNode)#488 (4) {
      ["_tag"]=>
      string(6) "paused"
      ["_attributeHash"]=>
      array(1) {
        ["xmlns"]=>
        string(37) "http://jabber.org/protocol/chatstates"
      }
      ["_children"]=>
      NULL
      ["_data"]=>
      string(0) ""
    }
  }
  ["_data"]=>
  string(0) ""
}
```
