### PR TITLE
Handle status == ok on codeRequest response.

### DIFF
--- a/src/php/whatsprot.class.php
+++ b/src/php/whatsprot.class.php
@@ -297,7 +297,20 @@ class WhatsProt
             print_r($response);
         }
 
-        if ($response->status != 'sent') {
+        if ($response->status == 'ok') {
+            $this->eventManager()->fire('onCodeRegister', array(
+                $this->phoneNumber,
+                $response->login,
+                $response->pw,
+                $response->type,
+                $response->expiration,
+                $response->kind,
+                $response->price,
+                $response->cost,
+                $response->currency,
+                $response->price_expiration
+            ));
+        } else if ($response->status != 'sent') {
             if (isset($response->reason) && $response->reason == "too_recent") {
                 $this->eventManager()->fire('onCodeRequestFailedTooRecent', array($this->phoneNumber, $method, $response->reason, $response->retry_after));
                 $minutes = round($response->retry_after / 60);


### PR DESCRIPTION
It looks like the response for codeRequest can say it is ok and
don't need to send the code on a sms. If so, fire a onCodeRegister
event with the password included on the reponse.
