### PR TITLE
Add toString method to ProtocolNode class

### DIFF
--- a/src/php/protocol.class.php
+++ b/src/php/protocol.class.php
@@ -231,6 +231,23 @@ class ProtocolNode
             $this->attributeHash['t'] = time();
         }
     }
+    
+    /**
+     * Print human readable ProtocolNode object
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $readableObject = array(
+            'tag'           => $this->tag,
+            'attributeHash' => $this->attributeHash,
+            'children'      => $this->children,
+            'data'          => $this->data
+        );
+
+        return print_r( $readableObject, true );
+    }
 
 }
 


### PR DESCRIPTION
This change is very helpful when using the events and want to print this object or convert it to JSON format.

For example:

``` php
    /**
     * Event fired when was get an error
     *
     * @param string $phone
     * @param \WhatsApi\Nodes\ProtocolNode $error
     */
    public function onGetError(
      $phone,
      $error
    )
    {
      $result = array(
        'sender' => $phone,
        'error'  => (string)$error  //Casting to force object conversion to string
      );

      echo json_encode( $result );
    }
```
