### PR TITLE
Parse Emoticons When Sending Broadcasts

### DIFF
--- a/src/php/whatsprot.class.php
+++ b/src/php/whatsprot.class.php
@@ -585,6 +585,7 @@ class WhatsProt
      */
     public function sendBroadcastMessage($targets, $message)
     {
+    	$message = $this->parseMessageForEmojis($message);
         $bodyNode = new ProtocolNode("body", null, null, $message);
         $this->sendBroadcast($targets, $bodyNode, "text");
     }


### PR DESCRIPTION
Hello,

With the current version, emoticons are not parsed when sending a broadcast.
I just added the method that will do this purpose.

Best regards
