### PR TITLE
Update whatsprot.class.php

### DIFF
--- a/src/php/whatsprot.class.php
+++ b/src/php/whatsprot.class.php
@@ -2061,7 +2061,7 @@ class WhatsProt
         }
         if ($node->getTag() == "iq"
             && $node->getAttribute('type') == "get"
-            && $node->getChild(0)->getTag() == "ping") {
+            && $node->getAttribute('xmlns') == "urn:xmpp:ping") {
             $this->eventManager()->firePing(
                 $this->phoneNumber,
                 $node->getAttribute('id')


### PR DESCRIPTION
PHP Fatal error:  Call to a member function getTag() on a non-object in WhatsAPI/whatsprot.class.php on line 2064.

Error while receiving ping. Child element is NULL/empty in the received ping.
