### PR TITLE
Prevent Array To String Conversion Notice

### DIFF
--- a/src/php/mediauploader.php
+++ b/src/php/mediauploader.php
@@ -61,6 +61,10 @@ class WhatsMediaUploader
         $boundary = "zzXXzzYYzzXXzzQQ";
         $contentlength = 0;
 
+        if(is_array($to)) {
+            $to = implode(',', $to);
+        }
+
         $hBAOS = "--" . $boundary . "\r\n";
         $hBAOS .= "Content-Disposition: form-data; name=\"to\"\r\n\r\n";
         $hBAOS .= $to . "\r\n";


### PR DESCRIPTION
When you send a broadcast, the $to variable is an array. So, when you concatenate $to with a string you are going to get "Array to String conversion notice."
