### PR TITLE
firePresence return "unavailable"

### DIFF
--- a/src/php/whatsprot.class.php
+++ b/src/php/whatsprot.class.php
@@ -2065,15 +2065,24 @@ class WhatsProt
                 }
             $this->sendClearDirty($categories);
         }
-        if (strcmp($node->getTag(), "presence") == 0
+if (strcmp($node->getTag(), "presence") == 0
             && strncmp($node->getAttribute('from'), $this->phoneNumber, strlen($this->phoneNumber)) != 0
-            && strpos($node->getAttribute('from'), "-") == false
-            && $node->getAttribute('type') != null) {
+            && strpos($node->getAttribute('from'), "-") == false) {
+            $presence = array();
+            if($node->getAttribute('type') == null){
             $this->eventManager()->firePresence(
                 $this->phoneNumber,
                 $node->getAttribute('from'),
-                $node->getAttribute('type')
+                $presence['type'] = "available"
             );
+            }
+            else{
+            $this->eventManager()->firePresence(
+                $this->phoneNumber,
+                $node->getAttribute('from'),
+                $presence['type'] = "unavailable"
+            );
+            }
         }
         if ($node->getTag() == "presence"
             && strncmp($node->getAttribute('from'), $this->phoneNumber, strlen($this->phoneNumber)) != 0


### PR DESCRIPTION
A fix for firePresence. When using the event and want the $type value, it only shows 'unavailable', now returns also 'available'.

Fix by @cwone and me.
