### PR TITLE
Update buildIdentity

### DIFF
--- a/src/php/whatsprot.class.php
+++ b/src/php/whatsprot.class.php
@@ -1632,9 +1632,9 @@ class WhatsProt
      * @param  string $identity A user string
      * @return string Correctly formatted identity
      */
-    protected function buildIdentity($number, $identity)
+    protected function buildIdentity($number, $salt = "")
     {
-        return strtolower(urlencode(sha1($identity + $number, true)));
+        return strtolower(urlencode(sha1(strrev($salt + $number), true)));
     }
 
     protected function checkIdentity($identity)


### PR DESCRIPTION
When using requestCode, if an identity is not provided, it will always return the same id.

```
%da9%a3%ee%5ekk%0d2u%bf%ef%95%60%18%90%af%d8%07%09
```

So now, for generating the identity is also used the number.
