### PR TITLE
Add Composer support (Small change)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ pip-log.txt
 
 # Komodo Project
 .komodoproject
+
+# Composer
+/vendor
+/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "venomous0x/whats-api",
+    "description": "Interface to WhatsApp Messenger",
+    "license": "MIT",
+    "authors": [
+        {
+            "role": "TODO",
+            "name": "Firstname Lastname",
+            "email": "email@example.com"
+        }
+    ],
+    "autoload": {
+        "classmap": [
+            "src/whatsprot.class.php",
+            "src/events"
+        ]
+    },
+    "require": {
+        "ext-curl": "*"
+    }
+}


### PR DESCRIPTION
I've left this change intentionally small it should in now way affect current usages of WhatsAPI.

Before merging make sure to edit the **authors** part of the composer.json.

Only autloading of the `WhatsProt` and all classes in the events dir is done. From what I could find these are the only classes consumers communicate with?

This fixes #602
